### PR TITLE
Bump normalize-url to version 4.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -442,7 +442,7 @@
         "http-cache-semantics": "^4.0.0",
         "keyv": "^3.0.0",
         "lowercase-keys": "^2.0.0",
-        "normalize-url": "^4.1.0",
+        "normalize-url": ">=4.5.1",
         "responselike": "^1.0.2"
       },
       "dependencies": {


### PR DESCRIPTION
The normalize-url package before 4.5.1, 5.x before 5.3.1, and 6.x before 6.0.1 for Node.js has a ReDoS issue (CVE-2021-33502). This commit bumps normalize-url to a safe(r) version.