### PR TITLE
Bump xmldom to version 0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1785,7 +1785,7 @@
       "requires": {
         "base64-js": "^1.2.3",
         "xmlbuilder": "^9.0.7",
-        "xmldom": ">=0.5.0
+        "xmldom": ">=0.7.0"
       }
     },
     "prepend-http": {


### PR DESCRIPTION
Because of CVE-2021-32796